### PR TITLE
.Net 4.5 framwork target added 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ dotnet: 1.0.1
 
 script:
   - dotnet restore
-  - dotnet build -c Release
+  - dotnet build ./Mailjet.Client/Mailjet.Client.csproj -f netstandard1.1 -c Release
+  - dotnet build ./Mailjet.ConsoleApplication/Mailjet.ConsoleApplication.csproj -c Release
   - dotnet test ./Mailjet.Tests/Mailjet.Tests.csproj -c Release

--- a/Mailjet.Client/Mailjet.Client.csproj
+++ b/Mailjet.Client/Mailjet.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Version>1.0.0-rc</Version>
     <Authors>Dimitar Kostov, Mailjet DevRel Team</Authors>
@@ -24,4 +24,9 @@ Documentation: https://dev.mailjet.com/guides/
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.1' ">
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
.Net 4.5 framwork target added in the project config to avoid the netstadard dependencies pollution when installing this package to a classic .NET 4.5 that still uses packages.config