### PR TITLE
Fix(TransactionnalEmail) - Made advandeErrorHandling be parametrized

### DIFF
--- a/Mailjet.Client/TransactionalEmails/MailjetClientExtensions.cs
+++ b/Mailjet.Client/TransactionalEmails/MailjetClientExtensions.cs
@@ -25,16 +25,16 @@ namespace Mailjet.Client.TransactionalEmails
         /// </summary>
         public static Task<TransactionalEmailResponse> SendTransactionalEmailAsync(
             this IMailjetClient mailjetClient,
-            TransactionalEmail transactionalEmail, bool isSandboxMode = false)
+            TransactionalEmail transactionalEmail, bool isSandboxMode = false, bool advanceErrorHandling = true)
         {
-            return mailjetClient.SendTransactionalEmailsAsync(new[] {transactionalEmail}, isSandboxMode);
+            return mailjetClient.SendTransactionalEmailsAsync(new[] {transactionalEmail}, isSandboxMode, advanceErrorHandling);
         }
 
         /// <summary>
         /// Sends transactional emails using send API v3.1
         /// </summary>
         public static async Task<TransactionalEmailResponse> SendTransactionalEmailsAsync(this IMailjetClient mailjetClient,
-            IEnumerable<TransactionalEmail> transactionalEmails, bool isSandboxMode = false)
+            IEnumerable<TransactionalEmail> transactionalEmails, bool isSandboxMode = false, bool advanceErrorHandling = true)
         {
             if (transactionalEmails.Count() > SendV31.MaxEmailsPerBatch || !transactionalEmails.Any())
                 throw new MailjetClientConfigurationException($"Send Emails API v3.1 allows to send not more than {SendV31.MaxEmailsPerBatch} emails per call");
@@ -43,7 +43,7 @@ namespace Mailjet.Client.TransactionalEmails
             {
                 Messages = transactionalEmails.ToList(),
                 SandboxMode = isSandboxMode,
-                AdvanceErrorHandling = true
+                AdvanceErrorHandling = advanceErrorHandling
             };
 
             var clientRequest = new MailjetRequest

--- a/Mailjet.Tests/Integration/SendTransactionalEmailIntegrationTests.cs
+++ b/Mailjet.Tests/Integration/SendTransactionalEmailIntegrationTests.cs
@@ -107,6 +107,55 @@ namespace Mailjet.Tests.Integration
             Assert.AreEqual("TemplateID", error.ErrorRelatedTo.Single());
         }
 
+        [TestMethod]
+        async public System.Threading.Tasks.Task SendTransactionalEmailAsync_TemplateIdReturnsWrongSenderType_advanceErrorHandlingTrue()
+        {
+            System.Collections.Generic.Dictionary<string, object> variables = new System.Collections.Generic.Dictionary<string, object>() { { "actionLink", "https://anywhere.com" } };
+
+            var email = new TransactionalEmailBuilder()
+                .WithFrom(new SendContact(_senderEmail))
+                .WithTo(new SendContact(_senderEmail))
+                .WithTemplateId(3120707)
+                .WithVariables(variables)
+                .Build();
+
+
+            // invoke API to send email
+            var response = await _client.SendTransactionalEmailAsync(email, advanceErrorHandling: true);
+
+            Assert.AreEqual(1, response.Messages.Length);
+            var message = response.Messages[0];
+
+            Assert.AreEqual("error", message.Status);
+            Assert.AreEqual(1, message.Errors.Count);
+
+            var error = message.Errors.Single();
+            Assert.AreEqual(400, error.StatusCode);
+        }
+
+        [TestMethod]
+        async public System.Threading.Tasks.Task SendTransactionalEmailAsync_TemplateIdReturnsWrongSenderType_advanceErrorHandlingFalse()
+        {
+            System.Collections.Generic.Dictionary<string, object> variables = new System.Collections.Generic.Dictionary<string, object>() { { "actionLink", "https://anywhere.com" } };
+
+            var email = new TransactionalEmailBuilder()
+                .WithFrom(new SendContact(_senderEmail))
+                .WithTo(new SendContact(_senderEmail))
+                .WithTemplateId(3120707)
+                .WithVariables(variables)
+                .Build();
+
+
+            // invoke API to send email
+            var response = await _client.SendTransactionalEmailAsync(email, advanceErrorHandling: false);
+
+            Assert.AreEqual(1, response.Messages.Length);
+            var message = response.Messages[0];
+
+            Assert.AreEqual("success", message.Status);
+            Assert.IsNull(message.Errors);
+        }
+
         public static async Task<string> GetValidSenderEmail(MailjetClient client)
         {
             MailjetRequest request = new MailjetRequest

--- a/Mailjet.Tests/Mailjet.Tests.csproj
+++ b/Mailjet.Tests/Mailjet.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>    
+   
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR allows the parameter advanceErrorHandling to be passed as parameter in order to overcome #69 

When setting this value to false, the mail would get sent whithout considering the typing problem of a transactionnal template edited in the web interface.

I bumped the targetFramework to version 2.0 but I believe it can be reverted to version 1.1.