### PR TITLE
Transaction email error handling, closes #85

### DIFF
--- a/Mailjet.Client/Exceptions/MailjetClientConfigurationException.cs
+++ b/Mailjet.Client/Exceptions/MailjetClientConfigurationException.cs
@@ -1,8 +1,6 @@
-﻿using System;
-
-namespace Mailjet.Client.Exceptions
+﻿namespace Mailjet.Client.Exceptions
 {
-    public class MailjetClientConfigurationException : Exception
+    public class MailjetClientConfigurationException : MailjetException
     {
         public MailjetClientConfigurationException(string message) : base(message)
         {

--- a/Mailjet.Client/Exceptions/MailjetException.cs
+++ b/Mailjet.Client/Exceptions/MailjetException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Mailjet.Client.Exceptions
+{
+    public class MailjetException : Exception
+    {
+        public MailjetException(string message) : base(message)
+        {
+        }
+
+        public MailjetException(string message, Exception exception): base(message, exception)
+        {
+        }
+    }
+}

--- a/Mailjet.Client/Exceptions/MailjetServerException.cs
+++ b/Mailjet.Client/Exceptions/MailjetServerException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Mailjet.Client.Exceptions
+{
+    public class MailjetServerException : MailjetException
+    {
+        public int HttpCode { get; set; }
+
+        public MailjetServerException(string message) : base(message)
+        {
+        }
+
+        public MailjetServerException(MailjetResponse mailjetResponse) : base(mailjetResponse.Content.ToString())
+        {
+            HttpCode = mailjetResponse.StatusCode;
+        }
+    }
+}

--- a/Mailjet.Client/Helpers/HttpContentHelper.cs
+++ b/Mailjet.Client/Helpers/HttpContentHelper.cs
@@ -1,0 +1,49 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Mailjet.Client.Helpers
+{
+    public static class HttpContentHelper
+    {
+        public static async Task<JObject> GetContentAsync(HttpResponseMessage responseMessage)
+        {
+            string cnt = null;
+
+            if (responseMessage.Content != null)
+            {
+                cnt = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+            }
+
+            JObject content;
+            if (!string.IsNullOrEmpty(cnt) && responseMessage.Content.Headers.ContentType.MediaType == MailjetConstants.JsonMediaType)
+            {
+                content = JObject.Parse(cnt);
+            }
+            else
+            {
+                content = new JObject();
+                content.Add("StatusCode", new JValue((int)responseMessage.StatusCode));
+            }
+
+            if (!responseMessage.IsSuccessStatusCode && !content.ContainsKey(MailjetConstants.ErrorInfo))
+            {
+                if (responseMessage.StatusCode == ((HttpStatusCode)429))
+                {
+                    content.Add(MailjetConstants.ErrorInfo, new JValue(MailjetConstants.TooManyRequestsMessage));
+                }
+                else if (responseMessage.StatusCode == HttpStatusCode.InternalServerError)
+                {
+                    content.Add(MailjetConstants.ErrorInfo, new JValue(MailjetConstants.InternalServerErrorGeneralMessage));
+                }
+                else
+                {
+                    content.Add(MailjetConstants.ErrorInfo, new JValue(responseMessage.ReasonPhrase));
+                }
+            }
+
+            return content;
+        }
+    }
+}

--- a/Mailjet.Client/IMailjetClient.cs
+++ b/Mailjet.Client/IMailjetClient.cs
@@ -15,11 +15,15 @@ namespace Mailjet.Client
         /// <summary>
         /// Sends a single transactional email using send API v3.1
         /// </summary>
+        /// <exception cref="MailjetClientConfigurationException">Thrown when email count exceeds the max allowed number</exception>
+        /// <exception cref="MailjetServerException">Thrown when generic error returned from the server</exception>
         Task<TransactionalEmailResponse> SendTransactionalEmailAsync(TransactionalEmail transactionalEmail, bool isSandboxMode = false, bool advanceErrorHandling = true);
 
         /// <summary>
         /// Sends transactional emails using send API v3.1
         /// </summary>
+        /// <exception cref="MailjetClientConfigurationException">Thrown when email count exceeds the max allowed number</exception>
+        /// <exception cref="MailjetServerException">Thrown when generic error returned from the server</exception>
         Task<TransactionalEmailResponse> SendTransactionalEmailsAsync(IEnumerable<TransactionalEmail> transactionalEmails, bool isSandboxMode = false, bool advanceErrorHandling = true);
     }
 }

--- a/Mailjet.Tests/HttpContentHelperTests.cs
+++ b/Mailjet.Tests/HttpContentHelperTests.cs
@@ -1,0 +1,101 @@
+﻿using Mailjet.Client;
+using Mailjet.Client.Helpers;
+using Mailjet.Client.TransactionalEmails.Response;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Mailjet.Tests
+{
+    [TestClass]
+    public class HttpContentHelperTests
+    {
+        [TestMethod]
+        public async Task GetContentAsync_WhenContentIsNull_ReturnsStatusCode()
+        {
+            // arrange
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK;
+
+            // act
+            var result = await HttpContentHelper.GetContentAsync(new HttpResponseMessage { StatusCode = expectedStatusCode });
+            HttpStatusCode statusCode = (HttpStatusCode) Enum.Parse(typeof(HttpStatusCode), result.Value<string>("StatusCode"));
+
+            // assert
+            Assert.AreEqual(expectedStatusCode, statusCode);
+        }
+
+        [TestMethod]
+        public async Task GetContentAsync_WhenContentNotNull_ParsesMessagesCorrectly()
+        {
+            // arrange
+            HttpResponseMessage response = 
+                GetHttpResponse(HttpStatusCode.BadRequest, "{\"Messages\":[{\"Status\":\"error\",\"Errors\":[{\"ErrorIdentifier\":\"6c1d35cb-3de8-495c-9d0e-0d563d2671da\",\"ErrorCode\":\"mj-0007\",\"StatusCode\":400,\"ErrorMessage\":\"You must provide at least one item in the collection.\",\"ErrorRelatedTo\":[\"To\"]}]}]}");
+
+            // act
+            var result = await HttpContentHelper.GetContentAsync(response);
+
+            // assert
+            Assert.IsTrue(result.Value<JArray>(nameof(TransactionalEmailResponse.Messages)).Any());
+        }
+
+        [TestMethod]
+        public async Task GetContentAsync_WhenContentIsGenericError_ReturnsErrorInfo()
+        {
+            // arrange
+            HttpResponseMessage response = 
+                GetHttpResponse(HttpStatusCode.Unauthorized, "{\"ErrorIdentifier\":\"e3f64f47-c99a-4a5a-b054-3ce1c5c7e4ce\",\"StatusCode\":401,\"ErrorMessage\":\"API key authentication/authorization failure. You may be unauthorized to access the API or your API key may be expired. Visit API keys management section to check your keys.\"}");
+
+            // act
+            var result = await HttpContentHelper.GetContentAsync(response);
+            string erroInfo = result.Value<string>(MailjetConstants.ErrorInfo);
+
+            // assert
+            Assert.IsNotNull(erroInfo);
+        }
+
+        [TestMethod]
+        public async Task GetContentAsync_WhenContentIsTooManyRequests_ReturnsCorrectErrorInfo()
+        {
+            // arrange
+            HttpResponseMessage response = GetHttpResponse((HttpStatusCode)429, "{\"ErrorIdentifier\":\"e3f64f47-c99a-4a5a-b054-3ce1c5c7e4ce\",\"StatusCode\":429,\"ErrorMessage\":\"Error!\"}");
+
+            // act
+            var result = await HttpContentHelper.GetContentAsync(response);
+            string erroInfo = result.Value<string>(MailjetConstants.ErrorInfo);
+
+            // assert
+            Assert.AreEqual(MailjetConstants.TooManyRequestsMessage, erroInfo);
+        }
+
+        [TestMethod]
+        public async Task GetContentAsync_WhenContentIsInternalServerError_ReturnsCorrectErrorInfo()
+        {
+            // arrange
+            HttpResponseMessage response = GetHttpResponse(HttpStatusCode.InternalServerError, "{\"ErrorIdentifier\":\"e3f64f47-c99a-4a5a-b054-3ce1c5c7e4ce\",\"StatusCode\":500,\"ErrorMessage\":\"Error!\"}");
+
+            // act
+            var result = await HttpContentHelper.GetContentAsync(response);
+            string erroInfo = result.Value<string>(MailjetConstants.ErrorInfo);
+
+            // assert
+            Assert.AreEqual(MailjetConstants.InternalServerErrorGeneralMessage, erroInfo);
+        }
+
+        private static HttpResponseMessage GetHttpResponse(HttpStatusCode expectedStatusCode, string contentString)
+        {
+            HttpResponseMessage response = new HttpResponseMessage
+            {
+                StatusCode = expectedStatusCode,
+                Content = new StringContent(contentString)
+            };
+
+            response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
When generic error is returned and the response cannot be parsed to TransactionalEmailResponse then MailjetServerException will be thrown containing the details of the error:

![image](https://github.com/mailjet/mailjet-apiv3-dotnet/assets/4784289/1954e630-a380-4ae3-9a0a-0e57c806a696)
